### PR TITLE
fix: 🐛 wrong order in hybrid full response

### DIFF
--- a/src/main/java/cz/muni/ics/oidc/ToOidcSynchronizer.java
+++ b/src/main/java/cz/muni/ics/oidc/ToOidcSynchronizer.java
@@ -75,14 +75,14 @@ public class ToOidcSynchronizer {
     public static final String RESPONSE_ID_TOKEN_TOKEN = RESPONSE_ID_TOKEN + " " + RESPONSE_TOKEN;
     public static final String RESPONSE_CODE_ID_TOKEN = RESPONSE_CODE + " " + RESPONSE_ID_TOKEN;
     public static final String RESPONSE_CODE_TOKEN = RESPONSE_CODE + " " + RESPONSE_TOKEN;
-    public static final String RESPONSE_CODE_ID_TOKEN_TOKEN = RESPONSE_CODE_ID_TOKEN + " " + RESPONSE_TOKEN;
+    public static final String RESPONSE_CODE_TOKEN_ID_TOKEN = RESPONSE_CODE_TOKEN + " " + RESPONSE_ID_TOKEN;
 //    public static final String RESPONSE_NONE = "none";
 
     // response types for grant types
     public static final String[] RESPONSE_TYPE_AUTH_CODE = { RESPONSE_CODE };
     public static final String[] RESPONSE_TYPE_IMPLICIT = { RESPONSE_TOKEN, RESPONSE_ID_TOKEN, RESPONSE_ID_TOKEN_TOKEN };
     public static final String[] RESPONSE_TYPE_HYBRID = {
-        RESPONSE_CODE_TOKEN, RESPONSE_CODE_ID_TOKEN, RESPONSE_CODE_ID_TOKEN_TOKEN
+        RESPONSE_CODE_TOKEN, RESPONSE_CODE_ID_TOKEN, RESPONSE_CODE_TOKEN_ID_TOKEN
     };
 
     public static final String PKCE_TYPE_NONE = "none";


### PR DESCRIPTION
Changed "code id_token token" to "code token id_token"