### PR TITLE
feat: 🎸 Enable PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jdbc:
   password: "password"
   url: "jdbc:mariadb://localhost:3306/oidcdb"
   driver_class_name: "org.mariadb.jdbc.Driver"
+  platform: "org.eclipse.persistence.platform.database.MySQLPlatform"
 
 ### CONNECTION TO PERUN RPC ###
 rpc:

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa</artifactId>
             <version>${eclipse-persistence-jpa.version}</version>

--- a/src/main/java/cz/muni/ics/oidc/data/DataBeans.java
+++ b/src/main/java/cz/muni/ics/oidc/data/DataBeans.java
@@ -31,9 +31,11 @@ public class DataBeans {
     }
 
     @Bean
-    public JpaVendorAdapter jpaAdapter() {
+    @Autowired
+    public JpaVendorAdapter jpaAdapter(@NonNull JdbcProperties jdbcProperties) {
         EclipseLinkJpaVendorAdapter adapter = new EclipseLinkJpaVendorAdapter();
-        adapter.setDatabasePlatform("org.eclipse.persistence.platform.database.MySQLPlatform");
+        adapter.setDatabasePlatform(jdbcProperties.getPlatform());
+
         adapter.setShowSql(false);
         return adapter;
     }

--- a/src/main/java/cz/muni/ics/oidc/props/JdbcProperties.java
+++ b/src/main/java/cz/muni/ics/oidc/props/JdbcProperties.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.persistence.platform.database.MySQLPlatform;
+import org.eclipse.persistence.platform.database.PostgreSQLPlatform;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
@@ -24,13 +26,21 @@ import javax.validation.constraints.NotBlank;
 @Validated
 public class JdbcProperties {
 
+    public static final String PLATFORM_MYSQL = MySQLPlatform.class.getName();
+    public static final String PLATFORM_PSQL = PostgreSQLPlatform.class.getName();
+
     @NotBlank private String driverClassName;
+    @NotBlank private String platform = PLATFORM_MYSQL;
     @NotBlank private String url;
     @NotBlank private String username;
     @NotBlank private String password;
 
     @PostConstruct
     public void postInit() {
+        if (!platform.equals(PLATFORM_MYSQL) && !platform.equals(PLATFORM_PSQL)) {
+            throw new IllegalArgumentException("Unrecognized JDBC platform '" + platform + "'!");
+        }
+
         log.info("Initialized JDBC properties");
         log.debug("{}", this);
     }
@@ -39,6 +49,7 @@ public class JdbcProperties {
     public String toString() {
         return "JdbcProperties{" +
                 "driverClassName='" + driverClassName + '\'' +
+                ", platform='" + platform + '\'' +
                 ", url='" + url + '\'' +
                 ", username='" + username + '\'' +
                 ", password=[PROTECTED]" +


### PR DESCRIPTION
A database platfomr should be specified using the `jdbc.platform`
property. Set it to the value
`org.eclipse.persistence.platform.database.MySQLPlatform` or
`org.eclipse.persistence.platform.database.PostgreSQLPlatform` to use
MySQL or PostgreSQL, dpeendning on your storage. By default it is set to
MySQL.