### PR TITLE
fix: 🐛 Limit pool size to 1 connection only

### DIFF
--- a/src/main/java/cz/muni/ics/oidc/data/DataBeans.java
+++ b/src/main/java/cz/muni/ics/oidc/data/DataBeans.java
@@ -27,6 +27,7 @@ public class DataBeans {
         ds.setJdbcUrl(jdbcProperties.getUrl());
         ds.setUsername(jdbcProperties.getUsername());
         ds.setPassword(jdbcProperties.getPassword());
+        ds.setMaximumPoolSize(1);
         return ds;
     }
 


### PR DESCRIPTION
We do not need more than one connection to the DB.